### PR TITLE
use `:erlang.nif_error/1` to avoid dialyzer warnings

### DIFF
--- a/src/picosat_nif.erl
+++ b/src/picosat_nif.erl
@@ -10,4 +10,4 @@ init() ->
 
 
 solve(_) ->
-    exit(unable_to_load_picosat_nif).
+    :erlang.nif_error(:not_loaded)

--- a/src/picosat_nif.erl
+++ b/src/picosat_nif.erl
@@ -10,4 +10,4 @@ init() ->
 
 
 solve(_) ->
-    :erlang.nif_error(:not_loaded)
+    erlang:nif_error(not_loaded)

--- a/src/picosat_nif.erl
+++ b/src/picosat_nif.erl
@@ -10,4 +10,4 @@ init() ->
 
 
 solve(_) ->
-    erlang:nif_error(not_loaded)
+    erlang:nif_error(not_loaded).


### PR DESCRIPTION
This is the same fix implemented here: https://github.com/riverrun/argon2_elixir/pull/21/files