### PR TITLE
Build compatibility for Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,42 @@
+!IF [where /R priv /Q Makefile.win.auto]
+# The file doesn't exist, so don't include it.
+!ELSE
+!INCLUDE priv\Makefile.win.auto
+!IF [del /Q /F priv\Makefile.win.auto] == 0
+!ENDIF
+!ENDIF
+
+C_SRC_DIR = c_src
+C_OUT_DIR = priv
+C_OUT_NAME = picosat_nif.dll
+C_OUTPUT = $(C_OUT_DIR)\$(C_OUT_NAME)
+
+NMAKE = nmake /$(MAKEFLAGS)
+# CFLAGS = -std=c99 -finline-functions -Wall  -fPIC
+# C99 not available in vs...
+CFLAGS = /std:c11 /DNGETRUSAGE=1 /Ob2 /Wall /I"$(C_SRC_DIR)"
+# LDFLAGS = -flat_namespace -undefined suppress -shared
+LDFLAGS = 
+
+all: $(C_OUTPUT)
+
+clean:
+	del /Q /F $(C_OUT_DIR)\*.auto
+	del /Q /F $(C_OUT_DIR)\*.dll
+	del /Q /F *.obj
+
+
+$(C_OUT_DIR)\Makefile.win.auto:
+	erl -noshell -s init stop -eval "io:setopts(standard_io, [{encoding, unicode}]), io:format(\"ERTS_INCLUDE_PATH=~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)])." > $@
+
+!IFDEF ERTS_INCLUDE_PATH
+$(C_OUTPUT):
+	if NOT EXIST "$(C_OUT_DIR)" mkdir "$(C_OUT_DIR)"
+	$(CC) $(CFLAGS) $(LDFLAGS) /I"$(ERTS_INCLUDE_PATH)" /LD /MD /Fe$@ $(C_SRC_DIR)\*.c
+!ELSE
+$(C_OUTPUT): $(C_OUT_DIR)\Makefile.win.auto
+	$(NMAKE) /F Makefile.win $(C_OUTPUT)
+	powershell -command "Start-Sleep -s 5"
+!ENDIF
+
+.PHONY: all clean

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,41 +1,24 @@
-!IF [where /R priv /Q Makefile.win.auto]
-# The file doesn't exist, so don't include it.
-!ELSE
-!INCLUDE priv\Makefile.win.auto
-!IF [del /Q /F priv\Makefile.win.auto] == 0
-!ENDIF
-!ENDIF
-
 C_SRC_DIR = c_src
 C_OUT_DIR = priv
 C_OUT_NAME = picosat_nif.dll
 C_OUTPUT = $(C_OUT_DIR)\$(C_OUT_NAME)
 
-NMAKE = nmake /$(MAKEFLAGS)
 # CFLAGS = -std=c99 -finline-functions -Wall  -fPIC
 # C99 not available in vs...
-CFLAGS = /std:c11 /DNGETRUSAGE=1 /Ob2 /Wall /I"$(C_SRC_DIR)"
+CFLAGS = /std:c11 /DNGETRUSAGE=1 /Ob2 /Wall /I"$(C_SRC_DIR)" /I"$(ERTS_INCLUDE_DIR)"
 # LDFLAGS = -flat_namespace -undefined suppress -shared
-LDFLAGS = 
+LDFLAGS =
 
 all: $(C_OUTPUT)
 
 clean:
-	del /Q /F $(C_OUT_DIR)\*.auto
 	del /Q /F $(C_OUT_DIR)\*.dll
+	del /Q /F $(C_OUT_DIR)\*.exp
+	del /Q /F $(C_OUT_DIR)\*.lib
 	del /Q /F *.obj
 
-
-$(C_OUT_DIR)\Makefile.win.auto:
-	erl -noshell -s init stop -eval "io:setopts(standard_io, [{encoding, unicode}]), io:format(\"ERTS_INCLUDE_PATH=~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)])." > $@
-
-!IFDEF ERTS_INCLUDE_PATH
 $(C_OUTPUT):
 	if NOT EXIST "$(C_OUT_DIR)" mkdir "$(C_OUT_DIR)"
-	$(CC) $(CFLAGS) $(LDFLAGS) /I"$(ERTS_INCLUDE_PATH)" /LD /MD /Fe$@ $(C_SRC_DIR)\*.c
-!ELSE
-$(C_OUTPUT): $(C_OUT_DIR)\Makefile.win.auto
-	$(NMAKE) /F Makefile.win $(C_OUTPUT)
-!ENDIF
+	$(CC) $(CFLAGS) $(LDFLAGS) /LD /MD /Fe$@ $(C_SRC_DIR)\*.c
 
 .PHONY: all clean

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,6 +1,6 @@
 C_SRC_DIR = c_src
 C_OUT_NAME = picosat_nif.dll
-C_OUTPUT = $(MIX_APP_PATH)\priv\$(C_OUT_NAME)
+C_OUTPUT = $(MIX_BUILD_PATH)\priv\$(C_OUT_NAME)
 
 # CFLAGS = -std=c99 -finline-functions -Wall  -fPIC
 # C99 not available in vs...
@@ -14,8 +14,8 @@ clean:
 	del /Q /F *.obj
 
 $(C_OUTPUT):
-	if NOT EXIST "$(MIX_APP_PATH)" mkdir "$(MIX_APP_PATH)"
-	if NOT EXIST "$(MIX_APP_PATH)\priv" mkdir "$(MIX_APP_PATH)\priv"
+	if NOT EXIST "$(MIX_BUILD_PATH)" mkdir "$(MIX_BUILD_PATH)"
+	if NOT EXIST "$(MIX_BUILD_PATH)\priv" mkdir "$(MIX_BUILD_PATH)\priv"
 	$(CC) $(CFLAGS) $(LDFLAGS) /LD /MD /Fe$@ $(C_SRC_DIR)\*.c
 
 .PHONY: all clean

--- a/Makefile.win
+++ b/Makefile.win
@@ -36,7 +36,6 @@ $(C_OUTPUT):
 !ELSE
 $(C_OUTPUT): $(C_OUT_DIR)\Makefile.win.auto
 	$(NMAKE) /F Makefile.win $(C_OUTPUT)
-	powershell -command "Start-Sleep -s 5"
 !ENDIF
 
 .PHONY: all clean

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,24 +1,21 @@
 C_SRC_DIR = c_src
-C_OUT_DIR = priv
 C_OUT_NAME = picosat_nif.dll
-C_OUTPUT = $(C_OUT_DIR)\$(C_OUT_NAME)
+C_OUTPUT = $(MIX_APP_PATH)\priv\$(C_OUT_NAME)
 
 # CFLAGS = -std=c99 -finline-functions -Wall  -fPIC
 # C99 not available in vs...
-CFLAGS = /std:c11 /DNGETRUSAGE=1 /Ob2 /Wall /I"$(C_SRC_DIR)" /I"$(ERTS_INCLUDE_DIR)"
+CFLAGS = /DNGETRUSAGE=1 /Ob2 /Wall /I"$(C_SRC_DIR)" /I"$(ERTS_INCLUDE_DIR)"
 # LDFLAGS = -flat_namespace -undefined suppress -shared
 LDFLAGS =
 
 all: $(C_OUTPUT)
 
 clean:
-	del /Q /F $(C_OUT_DIR)\*.dll
-	del /Q /F $(C_OUT_DIR)\*.exp
-	del /Q /F $(C_OUT_DIR)\*.lib
 	del /Q /F *.obj
 
 $(C_OUTPUT):
-	if NOT EXIST "$(C_OUT_DIR)" mkdir "$(C_OUT_DIR)"
+	if NOT EXIST "$(MIX_APP_PATH)" mkdir "$(MIX_APP_PATH)"
+	if NOT EXIST "$(MIX_APP_PATH)\priv" mkdir "$(MIX_APP_PATH)\priv"
 	$(CC) $(CFLAGS) $(LDFLAGS) /LD /MD /Fe$@ $(C_SRC_DIR)\*.c
 
 .PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Building on windows requires the Microsoft build tools (for C++/C) and `mix deps
 cmd /K "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
 ```
 
+Currently `mix compile` only succeeds on the 2nd run. That means `mix deps.compile` has to be run twice.
+
 ## License
 
 Apache 2.0, see `LICENSE.md`

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ def deps do
 end
 ```
 
+## Building on Windows
+
+Building on windows requires the Microsoft build tools (for C++/C) and `mix deps.compile` being run in a shell where the environment is set up correctly. This can be done by running the `vcvarsall.bat` script provided by the framework. The quickest way to get that is to paste this (replace the visual studio install path accordingly) into the `run` dialog (Win+R).
+
+```bat
+cmd /K "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+```
+
 ## License
 
 Apache 2.0, see `LICENSE.md`

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ either restaurant `1`, or `2`, but not `3`.
 
 Let's see what happens:
 
-    iex> votes = [ [1, 2, -3], [2, 3], [-2], [-1, 3] ]
-    ...> Picosat.solve(votes)
-    {:ok, [1, -2, 3]}
+```elixir
+iex> votes = [ [1, 2, -3], [2, 3], [-2], [-1, 3] ]
+...> Picosat.solve(votes)
+{:ok, [1, -2, 3]}
+```
 
 Nice! We have a solution, this tells us that choosing either restaurant `1` or `3` and not `2` will satisfy everyone.
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,11 @@ end
 
 ## Building on Windows
 
-Building on windows requires the Microsoft build tools (for C++/C) and `mix deps.compile` being run in a shell where the environment is set up correctly. This can be done by running the `vcvarsall.bat` script provided by the framework. The quickest way to get that is to paste this (replace the visual studio install path accordingly) into the `run` dialog (Win+R).
+Building on windows requires the Microsoft build tools (for C++/C) and `mix deps.compile` being run in a shell where the environment is set up correctly. This can be done by running the `vcvarsall.bat` script provided by the framework. The quickest way to get that is to paste this (replace the visual studio installation path accordingly) into the `run` dialog (<kbd>Win</kbd>+<kbd>R</kbd>).
 
 ```bat
 cmd /K "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
 ```
-
-Currently `mix compile` only succeeds on the 2nd run. That means `mix deps.compile` has to be run twice.
 
 ## License
 

--- a/c_src/picosat_nif.c
+++ b/c_src/picosat_nif.c
@@ -1,10 +1,8 @@
-#include <unistd.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/types.h>
 #include <errno.h>
-#include <sys/wait.h>
+#include <string.h>
 
 #include "erl_nif.h"
 
@@ -46,14 +44,16 @@ static ERL_NIF_TERM solve_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
     return enif_make_atom(env, "unknown");
   } else if (res == PICOSAT_SATISFIABLE) {
     unsigned int vars = picosat_variables(sat);
-    ERL_NIF_TERM solution[vars];
+    ERL_NIF_TERM *solution = malloc(vars * sizeof(ERL_NIF_TERM));
+
     for(int i=1;i<=vars;i++) {
       solution[i-1] = enif_make_int(env, i * picosat_deref(sat, i));
     }
 
     picosat_reset(sat);
-
-    return enif_make_list_from_array(env, solution, vars);
+    ERL_NIF_TERM ret = enif_make_list_from_array(env, solution, vars);
+    free(solution);
+    return ret;
   } else {
     picosat_reset(sat);
     return enif_make_atom(env, "picosat_error");

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Picosat.MixProject do
       deps: deps(),
       compilers: [:elixir_make | Mix.compilers()],
       make_clean: ["clean"],
+      make_targets: ["all"],
       elixirc_paths: elixirc_paths(Mix.env()),
       preferred_cli_env: preferred_cli_env(),
       description: "Bindings for the PicoSAT SAT solver",
@@ -27,7 +28,8 @@ defmodule Picosat.MixProject do
         "c_src/picosat_nif.c", 
         "priv/.gitkeep", 
         "mix.exs", 
-        "Makefile*", 
+        "Makefile", 
+        "Makefile.win", 
         "README.md", 
         "LICENSE.md"
       ],

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,6 @@ defmodule Picosat.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       compilers: [:elixir_make | Mix.compilers()],
-      make_makefile: "Makefile",
       make_clean: ["clean"],
       elixirc_paths: elixirc_paths(Mix.env()),
       preferred_cli_env: preferred_cli_env(),
@@ -28,7 +27,7 @@ defmodule Picosat.MixProject do
         "c_src/picosat_nif.c", 
         "priv/.gitkeep", 
         "mix.exs", 
-        "Makefile", 
+        "Makefile*", 
         "README.md", 
         "LICENSE.md"
       ],
@@ -51,7 +50,7 @@ defmodule Picosat.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:elixir_make, "~> 0.4", runtime: false},
+      {:elixir_make, "~> 0.6", runtime: false},
       {:ex_doc, ">= 0.0.0", only: [:docs]},
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}

--- a/test/picosat_test.exs
+++ b/test/picosat_test.exs
@@ -11,7 +11,58 @@ defmodule PicosatTest do
     ])
   end
 
+  test "plain" do
+    assert {:ok, [1]} = Picosat.solve([[1]])
+    assert {:ok, [1, 2]} = Picosat.solve([[1, 2]])
+    assert {:ok, [1, 2, 3]} = Picosat.solve([[1, 2, 3]])
+
+    assert {:ok, [1, 2, 3, 4]} = Picosat.solve([[1, 2], [3, 4]])
+    assert {:ok, [1, 2, 3, 4]} = Picosat.solve([[1], [2], [3], [4]])
+
+    assert {:ok, [1, 2, 3, 4]} = Picosat.solve([[2], [1], [4, 3]])
+  end
+
+  test "negative" do
+    assert {:ok, [-1]} = Picosat.solve([[-1]])
+    assert {:ok, [-1, -2]} = Picosat.solve([[-1, -2]])
+    assert {:ok, [-1, -2, -3]} = Picosat.solve([[-1, -2, -3]])
+  end
+
+  test "select_one" do
+    assert {:ok, [1, -2, -3]} = Picosat.solve([[-1, -2, -3], [1]])
+    assert {:ok, [-1, 2, -3]} = Picosat.solve([[-1, -2, -3], [2]])
+    assert {:ok, [-1, -2, 3]} = Picosat.solve([[-1, -2, -3], [3]])
+  end
+
+  test "list_large" do
+    check = fn num ->
+      assert {:ok, r} = Picosat.solve((for n <- 1 .. (num - 1), do: [-n]) ++ [[num]])
+      assert num = Enum.find(r, &(&1 == num))
+    end
+    check.(49)
+    check.(123)
+  end
+
+  test "sparse_list" do
+    assert {:ok, [1, -2, -3, -4, 5]} = Picosat.solve([[1], [5]])
+  end
+
+  test "sparse_list_large" do
+    check = fn num ->
+      assert {:ok, r} = Picosat.solve([[1], [num]])
+      assert num = Enum.find(r, &(&1 == num))
+    end
+    check.(50)
+    check.(5_000)
+    # check.(2_147_483_647 + 1) # Fails
+  end
+
+  test "different_lengths" do
+    assert {:ok, [1, -2, 3, -4, 5, -6]} = Picosat.solve([[1], [-2, -5, -6], [3, 5]])
+  end
+
   test "unsatisfiable" do
     assert {:error, :unsatisfiable} = Picosat.solve([[-1], [1]])
+    assert {:error, :unsatisfiable} = Picosat.solve([[-1, -2], []])
   end
 end


### PR DESCRIPTION
I managed to get everything to build and the unit tests to work. There are a ton of warnings from `cl`, but as far as I can tell, the lib works correctly, but for some reason the DLL is not copied on the first compile - at least on my system. Updated Readme for instructions.

I had to define `NGETRUSAGE` because that requires unix/GNU headers.

Added more tests due to the many warnings, not sure if the behaviour of test `Picosat.solve([[-1, -2], []])` is correct.


PS: Makefile.win is influenced by https://github.com/riverrun/argon2_elixir