### PR TITLE
Fix output directory for Windows build

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,6 +1,6 @@
 C_SRC_DIR = c_src
 C_OUT_NAME = picosat_nif.dll
-C_OUTPUT = $(MIX_BUILD_PATH)\priv\$(C_OUT_NAME)
+C_OUTPUT = $(MIX_APP_PATH)\priv\$(C_OUT_NAME)
 
 # CFLAGS = -std=c99 -finline-functions -Wall  -fPIC
 # C99 not available in vs...
@@ -14,8 +14,8 @@ clean:
 	del /Q /F *.obj
 
 $(C_OUTPUT):
-	if NOT EXIST "$(MIX_BUILD_PATH)" mkdir "$(MIX_BUILD_PATH)"
-	if NOT EXIST "$(MIX_BUILD_PATH)\priv" mkdir "$(MIX_BUILD_PATH)\priv"
+	if NOT EXIST "$(MIX_APP_PATH)" mkdir "$(MIX_APP_PATH)"
+	if NOT EXIST "$(MIX_APP_PATH)\priv" mkdir "$(MIX_APP_PATH)\priv"
 	$(CC) $(CFLAGS) $(LDFLAGS) /LD /MD /Fe$@ $(C_SRC_DIR)\*.c
 
 .PHONY: all clean


### PR DESCRIPTION
On Windows, the build process was placing the build output in `_build\dev\priv` rather than  `_build\dev\lib\picosat_elixir\priv`. This causes the NIF loading to fail. 

Changing  `$(MIX_BUILD_PATH)` to `$(MIX_APP_PATH)` in `Makefile.win` places the build output in the correct place.

See https://hexdocs.pm/mix/Mix.Project.html#build_path/1 vs https://hexdocs.pm/mix/Mix.Project.html#app_path/1