### PR TITLE
Fixes a build failure caused by a space in the path above the working dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CWD := $(shell pwd)
+CWD = .
 
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s erlang halt)
 MIX_BUILD_PATH ?= $(CWD)/priv
@@ -29,21 +29,21 @@ else ifneq (,$(findstring gcc, $(CC)))
 else
 	CFLAGS += -g
 endif
-CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR)
+CFLAGS += -fPIC -I "$(ERTS_INCLUDE_DIR)"
 LDFLAGS += -shared
 
 all: $(PICOSAT_BUILD_OUTPUT)
 
 clean:
-	rm -f $(PICOSAT_BUILD_OUTPUT)
+	rm -f "$(PICOSAT_BUILD_OUTPUT)"
 	rm -f $(PICOSAT_BUILD_DIR)/*.o
 
 analyze:
 	clang --analyze $(CFLAGS) $(C_SRC_DIR)/*.{c,h}
 
 $(PICOSAT_BUILD_OUTPUT): $(PICOSAT_BUILD_DIR)/picosat.o $(PICOSAT_BUILD_DIR)/picosat_nif.o
-	@mkdir -p $(PICOSAT_BUILD_OUTPUT_DIR)/priv
-	$(CC) $(LDFLAGS) $(LDLIBS) $(PICOSAT_BUILD_DIR)/picosat_nif.o $(PICOSAT_BUILD_DIR)/picosat.o -o $(PICOSAT_BUILD_OUTPUT)
+	@mkdir -p "$(PICOSAT_BUILD_OUTPUT_DIR)"
+	$(CC) $(LDFLAGS) $(LDLIBS) $(PICOSAT_BUILD_DIR)/picosat_nif.o $(PICOSAT_BUILD_DIR)/picosat.o -o "$(PICOSAT_BUILD_OUTPUT)"
 
 $(PICOSAT_BUILD_DIR)/picosat.o: $(C_SRC_DIR)/picosat.c $(C_SRC_DIR)/picosat.h
 	$(CC) $(CFLAGS) -o $(PICOSAT_BUILD_DIR)/picosat.o -c $<


### PR DESCRIPTION
Without this change, the build fails with this output when there is a space in the path leading to the working directory:
```
make: Circular /Users/admin/Desktop/picosat <- /Users/admin/Desktop/picosat dependency dropped.
make: Circular space <- /Users/admin/Desktop/picosat dependency dropped.
make: Circular space <- space dependency dropped.
make: Circular path <- /Users/admin/Desktop/picosat dependency dropped.
make: Circular path <- space dependency dropped.
make: Circular path <- path dependency dropped.
make: *** No rule to make target `bug/picosat_elixir/c_src/picosat_nif.c', needed by `path'.  Stop.
```

With the change the build succeeds.

Platform: Mac OS
```
> make --version
GNU Make 3.81

> xcode-select --version
xcode-select version 2416.

> sw_vers
ProductName:		macOS
ProductVersion:		26.3.1
BuildVersion:		25D2128
```